### PR TITLE
Update README.md - Correct syntax for the link is provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The service registers itself at the address matching http://notifications.$CF_AP
 
 # Prerequisites
 1. Running UAA. This requirement is typically satisfied by having [CloudFoundry](https://github.com/cloudfoundry/cf-release) deployed.
-1. Running MySQL instance. One option is to deploy the ]CloudFoundry MySQL release](https://github.com/cloudfoundry/cf-mysql-release).
+1. Running MySQL instance. One option is to deploy the [CloudFoundry MySQL release](https://github.com/cloudfoundry/cf-mysql-release).
 
 # UAA Client
 Notifications requires a UAA client to boot. The client can be created with the following properties:


### PR DESCRIPTION
[CloudFoundry MySQL release](https://github.com/cloudfoundry/cf-mysql-release).
- is the correct quote for the link display for cf-mysql-release.