### PR TITLE
Updates README.md to include `./update` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,13 +45,18 @@ authorities: scim.read,cloud_controller.admin
   ./bosh-lite/make_manifest
   ```
 
-4. Create and upload release:
+4. Update the sub-modules of the release
+  ```bash
+  ./update
+  ```
+
+5. Create and upload release:
   ```bash
   bosh create release
   bosh upload release
   ```
 
-5. Deploy
+6. Deploy
   ```bash
   bosh deploy
   bosh run errand deploy-notifications


### PR DESCRIPTION
- Fixes error '... has a glob that resolves to empty file list
  notifications/**/*'

When we were deploying notifications service as an application onto the
CloudFoundry (specifically our bosh-lite), we received the
aforementioned error. After some cursory googling, we arrived to the
conclusion that the `./update` command is to be executed before `bosh
create release`

Signed-off-by: Juan David Dominguez <jdominguez@pivotal.io>