### PR TITLE
Ensure that manifest.yml uses the app_domain property instead of the system domain to deploy the notifications app to CF

### DIFF
--- a/jobs/deploy-notifications/templates/manifest.yml.erb
+++ b/jobs/deploy-notifications/templates/manifest.yml.erb
@@ -3,7 +3,7 @@ applications:
   - name: notifications
     command: bin/notifications
     memory: 64M
-    domain: "<%= properties.domain %>"
+    domain: "<%= properties.notifications.app_domain %>"
     host: notifications
     diego: <%= properties.notifications.enable_diego %>
 env:


### PR DESCRIPTION
Greetings,

We are currently deploying Notifications in a CF environment that has a distinct domain for the system (api, etc) and another domain for apps.  It seems that the template for manifest.yml was using the system domain to try and deploy the app, and caused the application deploy to fail.  All we have to do is just change manifest.yml so it uses the app_domain property.

Let me know if you have any questions / concerns - Thanks!
Jeremy