### PR TITLE
Add buildpack_url parameter, for environments that might not be running the latest go buildpack

### DIFF
--- a/jobs/deploy-notifications/spec
+++ b/jobs/deploy-notifications/spec
@@ -19,6 +19,8 @@ properties:
     description: 'Password of the CF admin user'
   notifications.app_domain:
     description: 'Domain used to host application'
+  notifications.buildpack_url:
+    description: 'Optional parameter that specifies the url of the buildpack to use.  Helpful if your environment does not have the latest Go buildpack.'
   notifications.enable_diego:
     description: 'Enable deployment to diego'
   notifications.organization:

--- a/jobs/deploy-notifications/templates/manifest.yml.erb
+++ b/jobs/deploy-notifications/templates/manifest.yml.erb
@@ -6,6 +6,7 @@ applications:
     domain: "<%= properties.notifications.app_domain %>"
     host: notifications
     diego: <%= properties.notifications.enable_diego %>
+    <%= properties.notifications.buildpack_url ? "buildpack: " + properties.notifications.buildpack_url : "" %>
 env:
   CC_HOST: https://api.<%= properties.domain %>
   DATABASE_URL: "<%= properties.notifications.database.url %>"


### PR DESCRIPTION
Hello - I ran into another issue, where I tried deploying Notifications to an environment that is running go_buildpack v1.31 (CF 211), which does not support Go 1.5.  This is a Production environment, so the customer did not want to do an upgrade of the buildpack across the board at this time.  To get around this, I added a parameter - notifications.buildpack_url, which allows you to specify an optional buildpack url so the errand can successfully deploy the Notifications application.

Let me know if you have any questions / concerns / etc.  Thanks!
Jeremy