### PR TITLE
Database URL can be specified by component pieces in job spec

### DIFF
--- a/jobs/deploy-notifications/spec
+++ b/jobs/deploy-notifications/spec
@@ -56,8 +56,20 @@ properties:
     description: 'Admin client id of the UAA'
   notifications.uaa.admin_client_secret:
     description: 'Admin client secret of the UAA'
+  notifications.database.adapter:
+    description: 'Adapter (e.g. mysql or postgres) for the database connection'
+  notifications.database.username:
+    description: 'Username for the database connection'
+  notifications.database.password:
+    description: 'Password for the database connection'
+  notifications.database.host:
+    description: 'Host (IP or domain) for the database connection'
+  notifications.database.port:
+    description: 'Port for the database connection'
+  notifications.database.database:
+    description: 'Database name for the database connection'
   notifications.database.url:
-    description: 'URL pointing to database'
+    description: 'URL pointing to database. When present, overrides database adapter, username, password, host, port, and database properties.'
   notifications.database.max_open_connections:
     description: 'Maximum number of open connections to the database'
   notifications.encryption_key:

--- a/jobs/deploy-notifications/templates/manifest.yml.erb
+++ b/jobs/deploy-notifications/templates/manifest.yml.erb
@@ -1,4 +1,19 @@
 ---
+<%
+  database_url = nil
+  if_p("notifications.database.url") do |url|
+    database_url = url
+  end.else do
+    adapter = p("notifications.database.adapter")
+    username = p("notifications.database.username")
+    password = p("notifications.database.password")
+    host = p("notifications.database.host")
+    port = p("notifications.database.port")
+    database = p("notifications.database.database")
+
+    database_url = "#{adapter}://#{username}:#{password}@#{host}:#{port}/#{database}"
+  end
+%>
 applications:
   - name: notifications
     command: bin/notifications
@@ -9,7 +24,7 @@ applications:
     <%= properties.notifications.buildpack_url ? "buildpack: " + properties.notifications.buildpack_url : "" %>
 env:
   CC_HOST: https://api.<%= properties.domain %>
-  DATABASE_URL: "<%= properties.notifications.database.url %>"
+  DATABASE_URL: "<%= database_url %>"
   DB_MAX_OPEN_CONNS: "<%= properties.notifications.database.max_open_connections / properties.notifications.instance_count %>"
   DEFAULT_UAA_SCOPES: "cloud_controller.read,cloud_controller.write,openid,approvals.me,cloud_controller_service_permissions.read,scim.me,uaa.user,password.write,scim.userids,oauth.approvals"
   DOMAIN: "<%= properties.domain %>"


### PR DESCRIPTION
The URL format is framework-specific(-ish), and it's useful to be able to
specify the database connection information piece-by-piece. New
properties are for adapter, username, password, host, port, and
database.

If the database URL is still specified, that property takes priority
over the new properties.