### PR TITLE
Add metadata script for locking order

### DIFF
--- a/jobs/backup-restore-notifications/spec
+++ b/jobs/backup-restore-notifications/spec
@@ -8,6 +8,7 @@ templates:
   restore.sh.erb: bin/bbr/restore
   pre-restore-lock.sh.erb: bin/bbr/pre-restore-lock
   post-restore-unlock.sh.erb: bin/bbr/post-restore-unlock
+  metadata.sh: bin/bbr/metadata
 
 packages:
   - cf_cli

--- a/jobs/backup-restore-notifications/templates/metadata.sh
+++ b/jobs/backup-restore-notifications/templates/metadata.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+echo "---
+backup_should_be_locked_before:
+- job_name: cloud_controller_ng
+  release: capi
+- job_name: uaa
+  release: uaa
+restore_should_be_locked_before:
+- job_name: cloud_controller_ng
+  release: capi
+- job_name: uaa
+  release: uaa"


### PR DESCRIPTION
Hi!

We think that the lock scripts need to run before CC and UAA are locked - we see failures without this, as the `pre-restore-lock`  and `pre-backup-lock` scripts may attempt to `cf auth` after the CC and UAA have been stopped.

Thanks,
Chunyi && @henryaj 