### PR TITLE
Update backup-restore-notifications to consume a database link

### DIFF
--- a/jobs/backup-restore-notifications/spec
+++ b/jobs/backup-restore-notifications/spec
@@ -41,8 +41,6 @@ properties:
     description: 'Port for the database connection'
   notifications.database.database:
     description: 'Database name for the database connection'
-  notifications.database.url:
-    description: 'URL pointing to database. When present, overrides database adapter, username, password, host, port, and database properties.'
   ssl.skip_cert_verify:
     description: 'Whether to verify SSL certs when making HTTP and SMTP requests'
   release_level_backup:

--- a/jobs/backup-restore-notifications/spec
+++ b/jobs/backup-restore-notifications/spec
@@ -13,6 +13,11 @@ templates:
 packages:
   - notifications-cf-cli
 
+consumes:
+- name: database
+  type: database
+  optional: true
+
 properties:
   domain:
     description: 'Cloud Foundry System Domain'

--- a/jobs/backup-restore-notifications/templates/config.json.erb
+++ b/jobs/backup-restore-notifications/templates/config.json.erb
@@ -1,8 +1,19 @@
-{
-  "username":"<%= p('notifications.database.username') %>",
-  "password":"<%= p('notifications.database.password') %>",
-  "host":"<%= p('notifications.database.host') %>",
-  "port":<%= p('notifications.database.port') %>,
-  "database":"<%= p('notifications.database.database') %>",
-  "adapter":"mysql"
-}
+<%=
+    require 'json'
+
+    host = nil
+    if_p("notifications.database.host") do |host_property|
+      host = host_property
+    end.else do
+      host = link("database").instances[0].address
+    end
+
+    JSON.pretty_generate(
+      'username' => p("notifications.database.username"),
+      'password' => p("notifications.database.password"),
+      'host' => host,
+      'port' => p("notifications.database.port"),
+      'database' => p("notifications.database.database"),
+      "adapter":"mysql",
+    )
+%>


### PR DESCRIPTION
Hi folks,

We've made the smaller change to consume a database link for the host information in the same way that the deploy-notifications job does. We also removed the `notifications.database.url` property as it was not being used. Let us know if you have any other questions.

Thanks,
@davewalter and @kkallday, Release Engineering