### PR TITLE
Set CF_HOME to a temp dir to a avoid bug in autopilot

### DIFF
--- a/jobs/deploy-notifications/templates/deploy.sh.erb
+++ b/jobs/deploy-notifications/templates/deploy.sh.erb
@@ -1,7 +1,7 @@
 #!/bin/bash -exu
 
 export PATH="/var/vcap/packages/notifications-cf-cli/bin:/var/vcap/packages/notifications-jq/bin:$PATH"
-export CF_HOME=`pwd`/home/cf
+export CF_HOME=`mktemp -d 2>/dev/null || mktemp -d -t 'notifications-cf-cli'`
 export CF_DIAL_TIMEOUT=<%= properties.notifications.cf.dial_timeout %>
 
 SCHEME=https

--- a/jobs/deploy-notifications/templates/deploy.sh.erb
+++ b/jobs/deploy-notifications/templates/deploy.sh.erb
@@ -226,6 +226,12 @@ function print_deployment_status() {
   echo "Deployment succeeded!"
 }
 
+function cleanup_cf_home() {
+  if [[ -d "${CF_HOME}" ]]; then
+    rm -rf "${CF_HOME}"
+  fi
+}
+
 cf -v
 
 validate_database_connection_count
@@ -238,3 +244,4 @@ create_logging_service
 scale_app_up
 set_default_template
 print_deployment_status
+cleanup_cf_home


### PR DESCRIPTION
Hi,

We recently colocated both the deploy-notifications and deploy-notifications-ui errands on the same instance, which surfaced a bug in autopilot where `cf install-plugin autopilot -f` attempts to uninstall and reinstall autopilot. However, autopilot has not yet been updated to support this without panicking (see https://github.com/contraband/autopilot/pull/47).

As a short-term workaround, this PR changes the value of `CF_HOME` to a random directory so that the plugin is not already installed when the script runs. It also removes the directory at the end of the script so that running the errand repeatedly does not leave multiple copies of the directory lying around on the filesystem.

Let us know if you have any questions.
@davewalter and @michelleheh