### PR TITLE
restore-lock scripts should not run if notifications not deployed

### DIFF
--- a/jobs/backup-restore-notifications/templates/common.sh.erb
+++ b/jobs/backup-restore-notifications/templates/common.sh.erb
@@ -37,4 +37,9 @@ function cf_auth_and_target() {
 		echo "Notifications org/space not found; exiting"
 		exit 0
 	fi
+
+	if ! cf app $APP_NAME ; then
+		echo "Notifications app not deployed; exiting"
+		exit 0
+	fi
 }

--- a/jobs/backup-restore-notifications/templates/common.sh.erb
+++ b/jobs/backup-restore-notifications/templates/common.sh.erb
@@ -32,5 +32,9 @@ function cf_auth_and_target() {
 	cf auth $ADMIN_USER "$ADMIN_PASSWORD"
 	set -e
 	echo -e  "********************\n"
-	cf target -o $ORG -s $SPACE
+
+	if ! cf target -o $ORG -s $SPACE ; then
+		echo "Notifications org/space not found; exiting"
+		exit 0
+	fi
 }


### PR DESCRIPTION
We saw an issue with the notification backup/restore scripts when running them against an env in which notifications was not deployed. We have made the fix to exit if the org/space/app is not present. The same protection exists for other apps like BAM/autoscaling.

Can you please cut a release and let RelEng know. 

cc: @henryaj 