### PR TITLE
Change database link so it can consume cf-mysql-release

### DIFF
--- a/jobs/deploy-notifications/spec
+++ b/jobs/deploy-notifications/spec
@@ -12,7 +12,7 @@ packages:
 
 consumes:
 - name: database
-  type: database
+  type: internal-database
   optional: true
 
 properties:


### PR DESCRIPTION
This change allows a MySQL instance from cf-mysql-release to be consumed by the notifications release. It changes the link type to `internal-database`, which matches the link type provided by [cf-mysql-release](https://github.com/cloudfoundry/cf-mysql-release/blob/develop/jobs/mysql/spec#L56).