### PR TITLE
Use colocated cf-cli-release

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -2,10 +2,6 @@ cf_cli/autopilot-plugin-0.0.8.tgz:
   size: 4034969
   object_id: 3f006a6a-f4b4-4118-49dc-a1c6e0f15058
   sha: 807ba10b6cd1dd3dba9061fcb28bca61c2805e01
-cf_cli/cf-cli_6.31.0_linux_x86-64.tgz:
-  size: 6045122
-  object_id: 317f2cfc-a48d-4d83-44ec-6f93508754b3
-  sha: a8c3621b6d34c765e918efdce60e1cbf17ab9f37
 go/go1.9.4.linux-amd64.tar.gz:
   size: 105600650
   object_id: b726e757-47ed-4f03-61b0-d53bbef6cac0

--- a/jobs/backup-restore-notifications/spec
+++ b/jobs/backup-restore-notifications/spec
@@ -10,9 +10,6 @@ templates:
   post-restore-unlock.sh.erb: bin/bbr/post-restore-unlock
   metadata.sh: bin/bbr/metadata
 
-packages:
-  - notifications-cf-cli
-
 consumes:
 - name: database
   type: database

--- a/jobs/backup-restore-notifications/templates/common.sh.erb
+++ b/jobs/backup-restore-notifications/templates/common.sh.erb
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ex
 
-PATH="/var/vcap/packages/notifications-cf-cli/bin:$PATH"
+PATH="/var/vcap/packages/cf-cli-6-linux/bin:$PATH"
 
 SCHEME="https"
 DOMAIN="<%= properties.domain %>"

--- a/jobs/deploy-notifications/spec
+++ b/jobs/deploy-notifications/spec
@@ -8,7 +8,6 @@ templates:
 
 packages:
   - notifications
-  - notifications-cf-cli
   - notifications-jq
 
 consumes:

--- a/jobs/deploy-notifications/templates/deploy.sh.erb
+++ b/jobs/deploy-notifications/templates/deploy.sh.erb
@@ -1,6 +1,6 @@
 #!/bin/bash -exu
 
-export PATH="/var/vcap/packages/notifications-cf-cli/bin:/var/vcap/packages/notifications-jq/bin:$PATH"
+export PATH="/var/vcap/packages/cf-cli-6-linux/bin:/var/vcap/packages/notifications-jq/bin:$PATH"
 export CF_HOME=`mktemp -d 2>/dev/null || mktemp -d -t 'notifications-cf-cli'`
 export CF_DIAL_TIMEOUT=<%= properties.notifications.cf.dial_timeout %>
 
@@ -127,7 +127,7 @@ function push_app() {
         exit "${exit_code}"
       fi
     else
-      cf install-plugin /var/vcap/packages/notifications-cf-cli/plugins/autopilot -f
+      cf install-plugin /var/vcap/packages/cf-cli-6-linux/plugins/autopilot -f
 
       set +e
         cf zero-downtime-push "${APP_NAME}" -f manifest.yml -p "${PWD}" -s "${app_stack}"

--- a/jobs/destroy-notifications/spec
+++ b/jobs/destroy-notifications/spec
@@ -4,9 +4,6 @@ name: destroy-notifications
 templates:
   destroy.sh.erb: bin/run
 
-packages:
-  - notifications-cf-cli
-
 properties:
   domain:
     description: 'Cloud Foundry System Domain'

--- a/jobs/destroy-notifications/templates/destroy.sh.erb
+++ b/jobs/destroy-notifications/templates/destroy.sh.erb
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 
-export PATH="/var/vcap/packages/notifications-cf-cli/bin:$PATH"
+export PATH="/var/vcap/packages/cf-cli-6-linux/bin:$PATH"
 export CF_HOME=`pwd`/home/cf
 export CF_DIAL_TIMEOUT=<%= properties.notifications.cf.dial_timeout %>
 

--- a/jobs/test-notifications/spec
+++ b/jobs/test-notifications/spec
@@ -6,7 +6,6 @@ templates:
 
 packages:
   - notifications
-  - notifications-cf-cli
   - go
   - acceptance
 

--- a/jobs/test-notifications/templates/test.sh.erb
+++ b/jobs/test-notifications/templates/test.sh.erb
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e -x
 
-export PATH=$PATH:/var/vcap/packages/notifications-cf-cli/bin:/var/vcap/packages/go/bin
+export PATH=$PATH:/var/vcap/packages/cf-cli-6-linux/bin:/var/vcap/packages/go/bin
 export GOROOT=/var/vcap/packages/go
 export GOPATH="$(mktemp -d)/go"
 export HOME=`pwd`/home

--- a/packages/notifications-cf-cli/packaging
+++ b/packages/notifications-cf-cli/packaging
@@ -1,8 +1,0 @@
-#! /bin/bash -e
-
-mkdir -p ${BOSH_INSTALL_TARGET}/bin
-mkdir -p ${BOSH_INSTALL_TARGET}/plugins
-tar zxvf cf_cli/cf-cli_6.31.0_linux_x86-64.tgz
-tar zxvf cf_cli/autopilot-plugin-*.tgz
-cp cf ${BOSH_INSTALL_TARGET}/bin/
-cp autopilot ${BOSH_INSTALL_TARGET}/plugins/

--- a/packages/notifications-cf-cli/spec
+++ b/packages/notifications-cf-cli/spec
@@ -1,5 +1,0 @@
----
-name: notifications-cf-cli
-
-files:
-  - cf_cli/*.tgz


### PR DESCRIPTION
This PR removed the notifications-cf-cli package in favour of a colocated cf-cli-6-linux package from the [cf-cli-release](https://github.com/bosh-packages/cf-cli-release/).

Let me know if you have any questions.
Dave