### PR TITLE
Repush notifications app in bbr `post-restore-unlock` script

### DIFF
--- a/jobs/backup-restore-notifications/templates/post-restore-unlock.sh.erb
+++ b/jobs/backup-restore-notifications/templates/post-restore-unlock.sh.erb
@@ -7,11 +7,9 @@ source ${JOB_PATH}/bin/common
 
 cf_auth_and_target
 
-echo "Restoring route for $APP_NAME.$APP_DOMAIN"
+echo "Repushing application"
 
-cf map-route $APP_NAME --hostname $APP_NAME $APP_DOMAIN
-
-echo "DONE Restoring route for $APP_NAME.$APP_DOMAIN"
+/var/vcap/jobs/deploy-notifications/bin/run
 
 <% else %>
 echo "script deactivated due to release_level_backup being set to FALSE\n"


### PR DESCRIPTION
Hi notifications team,

Platform recovery team is working on a track to enable selective backups for our customers (selective as in choosing which bucket, droplets, packages they want to backup) to reduce the storage requirement for them. To ensure that `bbr restore PAS` still works when customers choose to skip droplets, we need to change the `post-restore-unlock` script of the notifications release, so that it pushes the applications again instead of `cf start` which could fail due to not finding the droplets.

Please let us know if you have any question/concerns regarding the feature and this PR.

Cheers,
Chunyi
@cloudfoundry-incubator/bosh-backup-and-restore-team 
@glestaris 