### PR TITLE
Check if deploy errand is colocated; if yes then run else use original logic

### DIFF
--- a/jobs/backup-restore-notifications/templates/post-restore-unlock.sh.erb
+++ b/jobs/backup-restore-notifications/templates/post-restore-unlock.sh.erb
@@ -7,11 +7,19 @@ source ${JOB_PATH}/bin/common
 
 cf_auth_and_target
 
-echo "Restoring route for $APP_NAME.$APP_DOMAIN"
+if ! ls /var/vcap/jobs/deploy-notifications/bin/run; then
+  echo "Restoring route for $APP_NAME.$APP_DOMAIN"
 
-cf map-route $APP_NAME --hostname $APP_NAME $APP_DOMAIN
+  cf map-route $APP_NAME --hostname $APP_NAME $APP_DOMAIN
 
-echo "DONE Restoring route for $APP_NAME.$APP_DOMAIN"
+  echo "DONE Restoring route for $APP_NAME.$APP_DOMAIN"
+else
+  echo "Repushing application $APP_NAME"
+
+  /var/vcap/jobs/deploy-notifications/bin/run
+
+  echo "DONE Repushing application $APP_NAME"
+fi
 
 <% else %>
 echo "script deactivated due to release_level_backup being set to FALSE\n"


### PR DESCRIPTION
To whom it may concern,

This is a PR linked to a previous [PR that was closed](https://github.com/cloudfoundry-incubator/notifications-release/pull/32). We have been gathering more opinions on our approach using the deploy-errand of optional components.

We have also updated the previous PR logic so that it maintains backwards compatibility with PAS versions without selective backups. This ensures that even if a PAS deployment has not colocated the errand with the `backup-restore-notifications` job that the unlock scripts will still work.

[#163618062]

Thanks,
cc @gmrodgers 